### PR TITLE
Greatly speed up __getitem__, fix reading in vectors from binary

### DIFF
--- a/word2vec/wordvectors.py
+++ b/word2vec/wordvectors.py
@@ -163,7 +163,6 @@ class WordVectors(object):
                 # read vector
                 vector = np.fromstring(fin.read(binary_len), dtype=np.float32)
                 vectors[i] = unitvec(vector)
-                fin.read(1)  # newline
 
         return cls(vocab=vocab, vectors=vectors)
 

--- a/word2vec/wordvectors.py
+++ b/word2vec/wordvectors.py
@@ -30,21 +30,21 @@ class WordVectors(object):
         self.vectors = vectors
         self.clusters = clusters
 
+        self.vocab_hash = {}
+        for i, word in enumerate(vocab):
+            self.vocab_hash[word] = i
+
     def ix(self, word):
         """
         Returns the index on self.vocab and `self.vectors` for `word`
         """
-        temp = np.where(self.vocab == word)[0]
-        if temp.size == 0:
-            raise KeyError('Word not in vocabulary')
-        else:
-            return temp[0]
+        return self.vocab_hash[word]
 
     def __getitem__(self, word):
         return self.get_vector(word)
 
     def __contains__(self, word):
-        return word in self.vocab
+        return word in self.vocab_hash
 
     def get_vector(self, word):
         """


### PR DESCRIPTION
66071e4e579e90984c42c8ec1a8338887d97b5ed makes it orders of magnitude faster to get the vectors for individual words - this is useful when trying to sum up the word vectors of the words in a paragraph (e.g. for sentiment analysis). fa1c5161146381062b9de3f5c29bea8fe064c0ae fixes the from_binary function for me - you should double check on your machine, but for me there were no newlines in the binary (maybe the binary format has changed since you first wrote that code).