### PR TITLE
Add an encoding parameter to from_binary and from_text (default to utf-8)

### DIFF
--- a/word2vec/wordvectors.py
+++ b/word2vec/wordvectors.py
@@ -136,7 +136,7 @@ class WordVectors(object):
         joblib.dump(self, fname)
 
     @classmethod
-    def from_binary(cls, fname, vocabUnicodeSize=78, desired_vocab=None):
+    def from_binary(cls, fname, vocabUnicodeSize=78, desired_vocab=None, encoding="utf-8"):
         """
         Create a WordVectors class based on a word2vec binary file
 
@@ -162,7 +162,7 @@ class WordVectors(object):
                 # read word
                 word = ''
                 while True:
-                    ch = fin.read(1).decode('ISO-8859-1')
+                    ch = fin.read(1).decode(encoding)
                     if ch == ' ':
                         break
                     word += ch
@@ -182,7 +182,7 @@ class WordVectors(object):
         return cls(vocab=vocab, vectors=vectors)
 
     @classmethod
-    def from_text(cls, fname, vocabUnicodeSize=78, desired_vocab=None):
+    def from_text(cls, fname, vocabUnicodeSize=78, desired_vocab=None, encoding="utf-8"):
         """
         Create a WordVectors class based on a word2vec text file
 
@@ -204,7 +204,7 @@ class WordVectors(object):
             vocab = np.empty(vocab_size, dtype='<U%s' % vocabUnicodeSize)
             vectors = np.empty((vocab_size, vector_size), dtype=np.float)
             for i, line in enumerate(fin):
-                line = line.decode('ISO-8859-1').strip()
+                line = line.decode(encoding).strip()
                 parts = line.split(' ')
                 word = parts[0]
                 include = desired_vocab is None or word in desired_vocab

--- a/word2vec/wordvectors.py
+++ b/word2vec/wordvectors.py
@@ -160,15 +160,15 @@ class WordVectors(object):
             binary_len = np.dtype(np.float32).itemsize * vector_size
             for i in range(vocab_size):
                 # read word
-                word = ''
+                word = b''
                 while True:
-                    ch = fin.read(1).decode(encoding)
-                    if ch == ' ':
+                    ch = fin.read(1)
+                    if ch == b' ':
                         break
                     word += ch
                 include = desired_vocab is None or word in desired_vocab
                 if include:
-                    vocab[i] = word
+                    vocab[i] = word.decode(encoding)
 
                 # read vector
                 vector = np.fromstring(fin.read(binary_len), dtype=np.float32)


### PR DESCRIPTION
Similar to #14, except an extra parameter `encoding` is added to `from_binary` and `from_text`. The default `encoding` is "utf-8" because I believe it is more widely used and is default to Python 3. 
It is more about giving the option of choosing the encoding than changing the encoding from iso8859-1 to utf8. 

Tested on both Python 2.7 and Python 3.4 with text and bin formats, seems to work. I don't have a Python 2.6 installed, but bytes literal is supported by Python 2.6, so it should work just fine.

