### PR TITLE
Build issue:  Setup for Mac OS 10.9.5 does not work: fatal error: 'ma…

### DIFF
--- a/word2vec-c/compute-accuracy.c
+++ b/word2vec-c/compute-accuracy.c
@@ -16,7 +16,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
-#include <malloc.h>
+//#include <malloc.h>
 #include <ctype.h>
 
 const long long max_size = 2000;         // max length of strings

--- a/word2vec-c/distance.c
+++ b/word2vec-c/distance.c
@@ -15,7 +15,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
-#include <malloc.h>
+#include <stdlib.h>
+//#include <malloc.h>
 
 const long long max_size = 2000;         // max length of strings
 const long long N = 40;                  // number of closest words that will be shown

--- a/word2vec-c/word-analogy.c
+++ b/word2vec-c/word-analogy.c
@@ -15,7 +15,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
-#include <malloc.h>
+#include <stdlib.h>
+//#include <malloc.h>
 
 const long long max_size = 2000;         // max length of strings
 const long long N = 40;                  // number of closest words that will be shown


### PR DESCRIPTION
…lloc.h' file not found #23 
This pull request is a fix for issue 23.  This branch did not build on Mac OS X 10.9 because of where the malloc.h files are located. This issue also existed in the original Google Code Archive, with a suggested solution of swapping out non-common include file "malloc.h" for to more portable "stdlib.h".  Fixing this issue means I can now build this source for Mac and use the library on my Mac OS 10.9.  