### PR TITLE
[Python 3 compatibility] Fixed bytes literal to string conversion

### DIFF
--- a/word2vec/scripts_interface.py
+++ b/word2vec/scripts_interface.py
@@ -142,7 +142,7 @@ def run_cmd(command, verbose=False):
                             stderr=subprocess.PIPE)
     if verbose:
         for line in proc.stdout:
-            line = str(line)
+            line = line.decode('ascii')
             sys.stdout.write(line)
             if 'ERROR:' in line:
                 raise Exception(line)

--- a/word2vec/tests/test_word2vec.py
+++ b/word2vec/tests/test_word2vec.py
@@ -2,6 +2,9 @@ from __future__ import division, print_function, unicode_literals
 
 import os
 import word2vec
+import io
+import sys
+
 
 input_ = os.path.expanduser('~/data/text')
 output_phrases = os.path.expanduser('~/data/text-phrases.txt')
@@ -86,3 +89,21 @@ def test_model_with_clusters():
     py_response = model.generate_response(indexes, metrics).tolist()
     assert len(py_response) == 30
     assert len(py_response[0]) == 3
+
+
+def test_verbosity_python3():
+    saved_stdout = sys.stdout
+
+    try:
+        sys.stdout = io.StringIO()
+
+        word2vec.word2vec(input_, output_bin, size=10, binary=1, verbose=True)
+        output = sys.stdout.getvalue()
+
+        assert "b'" not in output
+        assert "Starting training" in output
+        assert "\\r" not in output
+        assert "\r" in output
+
+    finally:
+        sys.stdout = saved_stdout


### PR DESCRIPTION
The conversion from a bytes literal to a string is handled incorrectly in the `run_cmd` method. This causes the output, when using Python 3, to be similar to:

```
$ python3
Python 3.4.3 (v3.4.3:9b73f1c3e601, Feb 23 2015, 02:52:03) 
[GCC 4.2.1 (Apple Inc. build 5666) (dot 3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import word2vec
>>> word2vec.word2vec('text8', 'text8.bin', verbose=True)
b'Starting training using file text8\n'b'100K\r200K\r300K\r400K\r500K\r600K\r700K\r800K\r900K\r1000K\r1100K\r1200K\r1300K
\r1400K\r1500K\r1600K\r1700K\r1800K\r1900K\r2000K\r2100K\r2200K\r2300K\r2400K\r2500K\r2600K
\r2700K\r2800K\r2900K\r3000K\r3100K\r3200K\r3300K\r3400K\r3500K\r3600K\r3700K\r3800K\r3900K
\r4000K\r4100K\r4200K\r4300K\r4400K\r4500K\r4600K\r4700K\r4800K\r4900K\r5000K\r5100K\r5200K
\r5300K\r5400K\r5500K\r5600K\r5700K\r5800K\r5900K\r6000K\r6100K\r6200K\r6300K\r6400K\r6500K
[...]\r12400K\r12500K\r12600K\r12700K\r12800K\r12900K\r13000K\r13100K\r13200K\r13300K\r13400K
\r13500K\r13600K\r13700K\r13800K\r13900K\r14000K\r14100K\r14200K\r14300K\r14400K\r14500K
\r14600K\r14700K\r14800K\r14900K\r15000K\r15100K\r15200K\r15300K\r15400K\r15500K\r15600K
\r15700K\r15800K\r15900K\r16000K\r16100K\r16200K\r16300K\r16400K\r16500K\r16600K\r16700K
\r16800K\r16900K\r17000K\rVocab size: 71291\n'b'Words in train file: 16718843\n'b'\rAlpha: 0.025000  
Progress: 0.01%  Words/thread/sec: 31.05k  \rAlpha: 0.024997  Progres[...]
```

This can be also seen in the Travis build: 
- Python 2 (correct): https://travis-ci.org/danielfrg/word2vec/jobs/109476159#L430
- Python 3 (garbage): https://travis-ci.org/danielfrg/word2vec/jobs/109476160#L428

As you can see, the string starts with `b'` and the carriage return and newline characters are not interpreted correctly.  This is pretty annoying and causes the terminal window to fill with garbage very quickly.

This PR fixes the problem using ASCII decoding of the bytes literal, and includes a unit test to check the function works as expected with both Python 2 and 3.
