### PR TITLE
docs: Fix a few typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ make env
 conda activate word2vec
 ```
 
-Install package for developmentt
+Install package for development
 
 ```
 make develop

--- a/word2vec/wordvectors.py
+++ b/word2vec/wordvectors.py
@@ -194,7 +194,7 @@ class WordVectors(object):
         ----------
         fname : path to file
         vocabUnicodeSize: the maximum string length (78, by default)
-        desired_vocab: if set any words that don't fall into this vocab will be droped
+        desired_vocab: if set any words that don't fall into this vocab will be dropped
 
         Returns
         -------


### PR DESCRIPTION
There are small typos in:
- CONTRIBUTING.md
- word2vec/wordvectors.py

Fixes:
- Should read `dropped` rather than `droped`.
- Should read `development` rather than `developmentt`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md